### PR TITLE
Fix Edit this page link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,7 +43,7 @@ module.exports = {
       {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: 'https://github.com/0xPolygon/polygon-sdk-docs',
+          editUrl: 'https://github.com/0xPolygon/polygon-sdk-docs/blob/main',
           showLastUpdateAuthor: false,
           showLastUpdateTime: false
         },


### PR DESCRIPTION
The `Edit this page` link in the footer of docs pages is broken, always points a non existing Github page, this PR fixes the URL.