### PR TITLE
Remove page edit prompt

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,7 +43,6 @@ module.exports = {
       {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: 'https://github.com/0xPolygon/polygon-sdk-docs',
           showLastUpdateAuthor: false,
           showLastUpdateTime: false
         },


### PR DESCRIPTION
This PR just removes the `Edit this page` prompt at the bottom of every page.