### PR TITLE
Hashicorp Vault: Add namespace cli flag

### DIFF
--- a/docs/cli-commands.mdx
+++ b/docs/cli-commands.mdx
@@ -1422,6 +1422,27 @@ Specifies the server URL for the service
 
 Specifies the name of the node for on-service record keeping. Default: `polygon-sdk-node`
 
+---
+
+<h4><i>namespace</i></h4>
+
+<Tabs>
+  <TabItem value="syntax" label="Syntax" default>
+
+    secrets generate [--namespace NAMESPACE]
+
+  </TabItem>
+  <TabItem value="example" label="Example">
+
+    secrets generate --namespace my-namespace
+
+  </TabItem>
+</Tabs>
+
+Specifies the namespace used for the Hashicorp Vault secrets manager. Default: `admin`
+
+---
+
 ## Responses
 
 ### Status Response


### PR DESCRIPTION
# Description

This PR adds support for the Hashicorp Vault namespace flag, introduced in [Polygon SDK PR#254](https://github.com/0xPolygon/polygon-sdk/pull/254)