### PR TITLE
Added newflag in loadbot commands

### DIFF
--- a/docs/get-started/cli-commands.mdx
+++ b/docs/get-started/cli-commands.mdx
@@ -1642,17 +1642,17 @@ The value to send in each transaction.
 
 ---
 
-<h4><i>maxconns</i></h4>
+<h4><i>max-conns</i></h4>
 
 <Tabs>
   <TabItem value="syntax" label="Syntax" default>
 
-    loadbot [--maxconns VALUE]
+    loadbot [--max-conns MAX_CONNECTIONS_COUNT]
 
   </TabItem>
   <TabItem value="example" label="Example">
 
-    loadbot --maxconns 1000
+    loadbot --max-conns 1000
 
   </TabItem>
 </Tabs>

--- a/docs/get-started/cli-commands.mdx
+++ b/docs/get-started/cli-commands.mdx
@@ -1642,6 +1642,24 @@ The value to send in each transaction.
 
 ---
 
+<h4><i>maxconns</i></h4>
+
+<Tabs>
+  <TabItem value="syntax" label="Syntax" default>
+
+    loadbot [--maxconns VALUE]
+
+  </TabItem>
+  <TabItem value="example" label="Example">
+
+    loadbot --maxconns 1000
+
+  </TabItem>
+</Tabs>
+
+Sets the maximum no.of connections allowed per host, Default: `2*tps`.
+
+---
 
 ## Genesis Template
 The genesis file should be used to set the initial state of the blockchain (ex. if some accounts should have a starting balance).


### PR DESCRIPTION
This PR adds a new flag `maxconns`, `maxconns` is used to set the maximum open connections per host. 

PSDK-[PR](https://github.com/0xPolygon/polygon-sdk/pull/295)