### PR TITLE
Prometheus network metrics

### DIFF
--- a/docs/configuration/enable-metrics.mdx
+++ b/docs/configuration/enable-metrics.mdx
@@ -21,3 +21,4 @@ The following metrics are available:
 | consensus_rounds                | Gauge         | Number of Rounds                                |
 | consensus_num_txs               | Gauge         | Number of Transactions in the latest block      |
 | consensus_block_interval        | Histogram     | Time between this and last block in seconds     |
+| network_peers                   | Gauge         | Number of Connected peers                       |

--- a/docs/get-started/cli-commands.mdx
+++ b/docs/get-started/cli-commands.mdx
@@ -1644,7 +1644,6 @@ The value to send in each transaction.
 
 <h4><i>max-conns</i></h4>
 
-
 <Tabs>
   <TabItem value="syntax" label="Syntax" default>
 
@@ -1652,7 +1651,7 @@ The value to send in each transaction.
 
   </TabItem>
   <TabItem value="example" label="Example">
-  
+
     loadbot --max-conns 1000
 
   </TabItem>

--- a/docs/get-started/cli-commands.mdx
+++ b/docs/get-started/cli-commands.mdx
@@ -1652,7 +1652,7 @@ The value to send in each transaction.
 
   </TabItem>
   <TabItem value="example" label="Example">
-    
+  
     loadbot --max-conns 1000
 
   </TabItem>

--- a/docs/get-started/cli-commands.mdx
+++ b/docs/get-started/cli-commands.mdx
@@ -1642,6 +1642,24 @@ The value to send in each transaction.
 
 ---
 
+<h4><i>maxconns</i></h4>
+
+<Tabs>
+  <TabItem value="syntax" label="Syntax" default>
+
+    loadbot [--maxconns VALUE]
+
+  </TabItem>
+  <TabItem value="example" label="Example">
+
+    loadbot --maxconns 1000
+
+  </TabItem>
+</Tabs>
+
+Sets the maximum no.of connections allowed per host, Default: `2*tps`.
+
+---
 
 ## Genesis Template
 The genesis file should be used to set the initial state of the blockchain (ex. if some accounts should have a starting balance).


### PR DESCRIPTION
Updated prometheus metrics doc to add `peers` network metric, which is introduced as part of PR[#302](https://github.com/0xPolygon/polygon-sdk/pull/302).